### PR TITLE
Fixing target compare tools folder

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,4 @@
 #! /usr/bin/env bash
-cp CompareTools.plist ~/Library/Application\ Support/com.fournova.Tower2/
-cp -R CompareScripts/* ~/Library/Application\ Support/com.fournova.Tower2/
+mkdir ~/Library/Application\ Support/com.fournova.Tower2/CompareTools
+cp CompareTools.plist ~/Library/Application\ Support/com.fournova.Tower2/CompareTools
+cp -R CompareScripts/* ~/Library/Application\ Support/com.fournova.Tower2/CompareTools


### PR DESCRIPTION
In Tower 2's recent version, custom compare tools shoud be under
CompareTools folder
